### PR TITLE
Agregar regresiones Ridge, Lasso y Elastic Net

### DIFF
--- a/TP-regresion-AA1.ipynb
+++ b/TP-regresion-AA1.ipynb
@@ -2940,6 +2940,63 @@
     }
    ],
    "execution_count": 116
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Modelos de regresión regularizados\n",
+    "Se entrenan regresiones Ridge, Lasso y Elastic Net para evaluar el efecto de la regularización sobre el desempeño del modelo y mitigar el sobreajuste.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Escalado de las variables para los modelos regularizados\n",
+    "scaler_reg = StandardScaler()\n",
+    "X_train_scaled = scaler_reg.fit_transform(x_train1)\n",
+    "X_test_scaled = scaler_reg.transform(x_test1)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Entrenamiento y evaluación de Ridge, Lasso y Elastic Net con validación cruzada\n",
+    "alphas_ridge = np.logspace(-3, 3, 40)\n",
+    "alphas_lasso = np.logspace(-4, 1, 40)\n",
+    "alphas_enet = np.logspace(-4, 1, 30)\n",
+    "l1_ratios = np.linspace(0.1, 0.9, 5)\n",
+    "\n",
+    "modelos_regularizados = {\n",
+    "    \"Ridge\": RidgeCV(alphas=alphas_ridge, cv=5),\n",
+    "    \"Lasso\": LassoCV(alphas=alphas_lasso, max_iter=5000, cv=5),\n",
+    "    \"ElasticNet\": ElasticNetCV(alphas=alphas_enet, l1_ratio=l1_ratios, max_iter=5000, cv=5)\n",
+    "}\n",
+    "\n",
+    "resultados_modelos = []\n",
+    "for nombre, modelo in modelos_regularizados.items():\n",
+    "    modelo.fit(X_train_scaled, y_train)\n",
+    "    y_pred_train = modelo.predict(X_train_scaled)\n",
+    "    y_pred_test = modelo.predict(X_test_scaled)\n",
+    "    resultados_modelos.append({\n",
+    "        \"Modelo\": nombre,\n",
+    "        \"Alpha óptimo\": getattr(modelo, \"alpha_\", np.nan),\n",
+    "        \"L1 ratio\": getattr(modelo, \"l1_ratio_\", np.nan),\n",
+    "        \"RMSE train\": mean_squared_error(y_train, y_pred_train, squared=False),\n",
+    "        \"RMSE test\": mean_squared_error(y_test, y_pred_test, squared=False),\n",
+    "        \"R2 train\": r2_score(y_train, y_pred_train),\n",
+    "        \"R2 test\": r2_score(y_test, y_pred_test)\n",
+    "    })\n",
+    "\n",
+    "resultados_reg = pd.DataFrame(resultados_modelos)\n",
+    "resultados_reg.round(4)\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- agrego un bloque de análisis para entrenar y evaluar regresiones Ridge, Lasso y Elastic Net
- preparo matrices de entrenamiento y prueba escaladas para que los modelos regularizados sean comparables


